### PR TITLE
Specify attachment index file based on definitions elsewhere

### DIFF
--- a/lib/Zendesk.pm
+++ b/lib/Zendesk.pm
@@ -24,7 +24,7 @@ sub new {
 
 sub download_attachments {
 	my $self = shift;
-	my $index_file = $self->{file};
+	my $index_file = $self->{indices_dir} . '/attachments.csv';
 	my $delay      = $self->{delay};
 
 	my $index = read_text $index_file;


### PR DESCRIPTION
Fixes https://github.com/scottdotjs/zendesk-flatfile/issues/2

May not be the right long-term solution, but allowed the script to progress for me.